### PR TITLE
Added es6 "module" key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "name": "causalityjs",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "A library for reactive programming based on Javascript proxies.",
     "main": "causality.js",
+    "module": "causality.js",
     "scripts": {
         "test": "mocha --require reify"
     },


### PR DESCRIPTION
This adds the "module" key to the package.json so the library can be used by snowpack (https://www.snowpack.dev/) and can also be imported via unpkg like so: 

```
<script type="module">
  import {create, repeat} from "https://unpkg.com/causalityjs?module";
</script>
```